### PR TITLE
Add configurable BeautyFort currency setting (default SEK)

### DIFF
--- a/admin/views/settings.php
+++ b/admin/views/settings.php
@@ -17,6 +17,8 @@ if (!defined('ABSPATH')) exit;
     <form method="post">
         <?php wp_nonce_field('nebf_save_settings'); ?>
 
+        <?php $selected_currency = get_option('nebf_currency', 'SEK'); ?>
+
         <table class="form-table">
             <tbody>
                 <tr>
@@ -54,6 +56,23 @@ if (!defined('ABSPATH')) exit;
 
                 <tr>
                     <th scope="row">
+                        <label for="nebf_currency"><?php esc_html_e('Currency', 'nebf-mvc'); ?></label>
+                    </th>
+                    <td>
+                        <select name="nebf_currency" id="nebf_currency">
+                            <option value="SEK" <?php selected($selected_currency, 'SEK'); ?>>SEK</option>
+                            <option value="NOK" <?php selected($selected_currency, 'NOK'); ?>>NOK</option>
+                            <option value="DKK" <?php selected($selected_currency, 'DKK'); ?>>DKK</option>
+                            <option value="EUR" <?php selected($selected_currency, 'EUR'); ?>>EUR</option>
+                            <option value="GBP" <?php selected($selected_currency, 'GBP'); ?>>GBP</option>
+                            <option value="USD" <?php selected($selected_currency, 'USD'); ?>>USD</option>
+                        </select>
+                        <p class="description"><?php esc_html_e('Select the currency used by your BeautyFort account. Default is SEK.', 'nebf-mvc'); ?></p>
+                    </td>
+                </tr>
+
+                <tr>
+                    <th scope="row">
                         <label for="nebf_margin_type"><?php esc_html_e('Profit Margin Type', 'nebf-mvc'); ?></label>
                     </th>
                     <td>
@@ -76,7 +95,7 @@ if (!defined('ABSPATH')) exit;
                     <td>
                         <input name="nebf_margin_value" type="number" step="0.01" min="0" id="nebf_margin_value"
                             value="<?php echo esc_attr((string) get_option('nebf_margin_value', '0')); ?>" class="small-text">
-                        <p class="description"><?php esc_html_e('Example: 25 means +25% in Percent mode, or +25 currency units in Fixed Amount mode.', 'nebf-mvc'); ?></p>
+                        <p class="description"><?php echo esc_html(sprintf(__('Example: 25 means +25%% in Percent mode, or +25 %s in Fixed Amount mode.', 'nebf-mvc'), $selected_currency)); ?></p>
                     </td>
                 </tr>
 

--- a/includes/Controllers/SettingsController.php
+++ b/includes/Controllers/SettingsController.php
@@ -9,6 +9,7 @@ if (!defined('ABSPATH')) exit;
  */
 class SettingsController extends AbstractAdminController
 {
+    private const ALLOWED_CURRENCIES = ['SEK', 'NOK', 'DKK', 'EUR', 'GBP', 'USD'];
 
     public function handle(): void
     {
@@ -40,11 +41,24 @@ class SettingsController extends AbstractAdminController
                 update_option('nebf_margin_value', max(0, $margin_value));
             }
 
+            if (isset($_POST['nebf_currency'])) {
+                $currency = strtoupper(sanitize_text_field((string) $_POST['nebf_currency']));
+                if (!in_array($currency, self::ALLOWED_CURRENCIES, true)) {
+                    $currency = 'SEK';
+                }
+
+                update_option('nebf_currency', $currency);
+            }
+
             // Feedback notice
             add_action('admin_notices', function () {
                 echo '<div class="notice notice-success is-dismissible"><p>'
                     . esc_html__('Settings saved successfully.', 'nebf-mvc') . '</p></div>';
             });
+        }
+
+        if (!get_option('nebf_currency')) {
+            update_option('nebf_currency', 'SEK');
         }
 
         $this->render('settings');


### PR DESCRIPTION
### Motivation
- Provide a configurable currency option because product prices depend on the merchant's BeautyFort account and should default to `SEK`.
- Make margin help text accurate when using fixed-margin mode by showing the selected currency.

### Description
- Add `nebf_currency` option handling with an allowed whitelist `['SEK','NOK','DKK','EUR','GBP','USD']` and fallback to `SEK` when input is invalid or missing in `includes/Controllers/SettingsController.php`.
- Ensure older installs receive a default `nebf_currency = 'SEK'` if the option is not present.
- Add a currency select field to the admin settings UI and use the selected currency in the margin help text in `admin/views/settings.php`.
- Files modified: `includes/Controllers/SettingsController.php`, `admin/views/settings.php`.

### Testing
- Ran PHP syntax checks: `php -l includes/Controllers/SettingsController.php` — succeeded. `php -l admin/views/settings.php` — succeeded.
- Attempted an automated UI screenshot via Playwright (`mcp__browser_tools__run_playwright_script`) which failed with `ERR_EMPTY_RESPONSE` because no local web server responded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69985802f75c8329a565140049998704)