### PR TITLE
Remove MVC wording from plugin metadata

### DIFF
--- a/ne-bf-woo-mvc.php
+++ b/ne-bf-woo-mvc.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * Plugin Name: NE BeautyFort Woo MVC
- * Description: MVC refactor of the BeautyFort WooCommerce integration.
+ * Plugin Name: NE BeautyFort Woo
+ * Description: BeautyFort WooCommerce integration.
  * Version: 1.0.0
  * Author: Nordic Equilibro
  * Text Domain: nebf-mvc


### PR DESCRIPTION
### Motivation
- Remove the `MVC` label from the plugin header to present a cleaner plugin name and description.

### Description
- Update the plugin header in `ne-bf-woo-mvc.php` to change the `Plugin Name` to `NE BeautyFort Woo` and simplify the `Description` to `BeautyFort WooCommerce integration.`

### Testing
- Ran a PHP syntax check with `php -l ne-bf-woo-mvc.php`, which reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69985a31c2348329adce710d5e0639eb)