### PR TITLE
Translate legacy Swedish comments and docs to English

### DIFF
--- a/_old/admin/admin-control-page.php
+++ b/_old/admin/admin-control-page.php
@@ -6,7 +6,7 @@ require_once plugin_dir_path(__FILE__) . 'pricing-page.php';
 require_once plugin_dir_path(__FILE__) . 'pricing-actions.php';
 
 /**
- * Registrera inställningar
+ * Register settings
  */
 add_action('admin_init', function () {
     register_setting(
@@ -45,7 +45,7 @@ add_action('admin_init', function () {
 });
 
 /**
- * Rendera admin-sidan
+ * Render admin page
  */
 function nebf_admin_page()
 {

--- a/_old/admin/products-page.php
+++ b/_old/admin/products-page.php
@@ -4,7 +4,7 @@ if (!defined('ABSPATH')) exit;
 function nebf_render_products_page()
 {
 
-    // --- Hämta produkter från DB ---
+    // --- Fetch products from DB ---
     if (function_exists('nebf_get_cached_products')) {
         $products = nebf_get_cached_products();
     } else {
@@ -36,19 +36,19 @@ function nebf_render_products_page()
     }
 
 
-    // --- Pagination & sortering ---
+    // --- Pagination & sorting ---
     $per_page = isset($_GET['per_page']) ? max(1, (int) $_GET['per_page']) : 100;
     $page     = isset($_GET['paged']) ? max(1, (int) $_GET['paged']) : 1;
     $orderby  = isset($_GET['orderby']) ? sanitize_text_field($_GET['orderby']) : 'fullname';
     $order    = isset($_GET['order']) ? strtoupper($_GET['order']) : 'ASC';
 
-    // --- Filter & sök ---
+    // --- Filter & search ---
     $search        = isset($_GET['s']) ? sanitize_text_field($_GET['s']) : '';
     $brand_f       = isset($_GET['brand']) ? sanitize_text_field($_GET['brand']) : '';
     $collection_f  = isset($_GET['collection']) ? sanitize_text_field($_GET['collection']) : '';
     $status_f      = isset($_GET['status']) ? sanitize_text_field($_GET['status']) : '';
 
-    // --- Dropdown-data ---
+    // --- Dropdown data ---
     $brands      = array_unique(array_filter(array_column($products, 'brand')));
     sort($brands);
     $collections = array_unique(array_filter(array_column($products, 'collection')));
@@ -57,7 +57,7 @@ function nebf_render_products_page()
     // --- FILTER ---
     $products = array_filter($products, function ($product) use ($search, $brand_f, $collection_f, $status_f) {
 
-        // Statusfilter
+        // Status filter
         if ($status_f) {
             $existing = get_posts([
                 'post_type'  => 'product',
@@ -71,13 +71,13 @@ function nebf_render_products_page()
             if ($status_f === 'not_imported' && $is_imported) return false;
         }
 
-        // Varumärke
+        // Brand
         if ($brand_f && strcasecmp($product['brand'] ?? '', $brand_f) !== 0) return false;
 
-        // Kollektion
+        // Collection
         if ($collection_f && strcasecmp($product['collection'] ?? '', $collection_f) !== 0) return false;
 
-        // Sök
+        // Search
         if ($search) {
             $haystack = strtolower(
                 ($product['fullname'] ?? '') . ' ' .
@@ -90,7 +90,7 @@ function nebf_render_products_page()
         return true;
     });
 
-    // --- SORTERING ---
+    // --- SORTING ---
     usort($products, function ($a, $b) use ($orderby, $order) {
         if ($orderby === 'status') {
             $valA = !empty(get_posts(['post_type' => 'product', 'meta_key' => '_beautyfort_id', 'meta_value' => $a['bf_id'], 'fields' => 'ids'])) ? 1 : 0;
@@ -117,7 +117,7 @@ function nebf_render_products_page()
 
 ?>
     <!-- ========================= -->
-    <!-- FORMULÄR / FILTER -->
+    <!-- FORM / FILTER -->
     <form method="get" style="margin-bottom:15px; display:flex; gap:10px; flex-wrap:wrap;">
         <input type="hidden" name="page" value="<?= esc_attr($_GET['page'] ?? '') ?>">
         <input type="number" name="per_page" value="<?= esc_attr($per_page) ?>" min="1" max="500">
@@ -151,7 +151,7 @@ function nebf_render_products_page()
         Synka till WooCommerce
     </button>
     <!-- ========================= -->
-    <!-- PRODUKTTABELL -->
+    <!-- PRODUCT TABLE -->
     <table class="widefat striped nebf-products-table">
         <thead>
             <tr>
@@ -160,8 +160,8 @@ function nebf_render_products_page()
                 <th>Bild</th>
                 <th><?= nebf_sort_link('fullname', $orderby, $order, 'Namn'); ?></th>
                 <th><?= nebf_sort_link('sku', $orderby, $order, 'SKU'); ?></th>
-                <th><?= nebf_sort_link('brand', $orderby, $order, 'Varumärke'); ?></th>
-                <th><?= nebf_sort_link('collection', $orderby, $order, 'Kollektion'); ?></th>
+                <th><?= nebf_sort_link('brand', $orderby, $order, 'Brand'); ?></th>
+                <th><?= nebf_sort_link('collection', $orderby, $order, 'Collection'); ?></th>
                 <th><?= nebf_sort_link('price', $orderby, $order, 'Kostpris'); ?></th>
                 <th>Försäljningspris</th>
                 <th>Marginal %</th>
@@ -180,12 +180,12 @@ function nebf_render_products_page()
                 $is_imported = nebf_is_product_synced($product['sku']); //!empty($existing);
                 $accordion_id = 'acc-' . $i;
 
-                // --- Beräkna försäljningspris och marginal ---
+                // --- Calculate sale price and margin ---
                 $cost_price = floatval($product['price'] ?? 0);
                 $margin_data = NEBF_Pricing_Engine::get_margin_data($product['bf_id']);
                 $sale_price  = NEBF_Pricing_Engine::calculate_price($product['bf_id'], $cost_price);
 
-                // Marginal i % (för display)
+                // Margin in % (for display)
                 $calc_margin = $cost_price > 0 ? round((($sale_price - $cost_price) / $cost_price) * 100, 2) : 0;
             ?>
                 <tr class="product-row" data-accordion="<?= esc_attr($accordion_id); ?>">

--- a/_old/admin/settings-action.php
+++ b/_old/admin/settings-action.php
@@ -2,7 +2,7 @@
 if (!defined('ABSPATH')) exit;
 
 /**
- * Hanterar POST-actions för inställningssidan
+ * Handles POST actions for the settings page
  */
 add_action('admin_init', 'nebf_handle_settings_actions');
 
@@ -11,7 +11,7 @@ function nebf_handle_settings_actions()
     if (!isset($_POST['nebf_action'])) return;
 
     // ==============================
-    // IMPORT PRODUKTER
+    // IMPORT PRODUCTS
     // ==============================
     if ($_POST['nebf_action'] === 'import_products') {
 

--- a/_old/admin/settings-page.php
+++ b/_old/admin/settings-page.php
@@ -4,7 +4,7 @@ function nebf_render_settings_tab()
     $last_fetch       = get_option('nebf_last_fetch');
     $last_fetch_count = get_option('nebf_last_fetch_count');
 
-    // Visa notices efter redirect
+    // Show notices after redirect
     if (isset($_GET['nebf_notice'])) {
         $type = $_GET['nebf_notice'] === 'success'
             ? 'notice-success'

--- a/_old/css/nebf-style.css
+++ b/_old/css/nebf-style.css
@@ -1,5 +1,5 @@
 /* =========================
-   Huvudrad
+   Main row
    ========================= */
 .nebf-products-table tr.product-row {
     cursor: pointer;
@@ -10,24 +10,24 @@
     background-color: #eef6ff;
 }
 
-/* Markerad rad (checkbox vald) */
+/* Selected row (checkbox checked) */
 .nebf-products-table tr.product-row.is-selected {
     background-color: #e6f4ea !important;
 }
 
-/* Extra tydlig vänsterkant */
+/* Extra visible left border */
 .nebf-products-table tr.product-row.is-selected td:first-child {
     box-shadow: inset 4px 0 0 #46b450;
 }
 
-/* Öppen rad */
+/* Open row */
 .product-row.is-selected {
     background: #e8f2ff;
     box-shadow: inset 3px 0 0 #2271b1;
 }
 
 /* =========================
-   Accordion-tabell
+   Accordion table
    ========================= */
 .nebf-inner-table {
     width: 100%;
@@ -50,7 +50,7 @@
 }
 
 /* =========================
-   Status-pill
+   Status pill
    ========================= */
 .status-pill {
     display: inline-block;
@@ -82,14 +82,14 @@
     color: #2271b1;
 }
 
-/* Standard chevron: pekar höger */
+/* Default chevron: points right */
 .product-row .dashicons {
     transition: transform 0.2s ease;
     display: inline-block;
-    transform: rotate(-90deg); /* pekar åt höger initialt */
+    transform: rotate(-90deg); /* points right initially */
 }
 
-/* Öppen rad: pekar nedåt */
+/* Open row: points down */
 .product-row.is-open .dashicons {
-    transform: rotate(0deg); /* pekar nedåt */
+    transform: rotate(0deg); /* points down */
 }

--- a/_old/includes/api-client.php
+++ b/_old/includes/api-client.php
@@ -83,7 +83,7 @@ function nebf_api_request_stockfile()
     $response = $bf->GetStockFileResponse ?? null;
 
 if (!$response) {
-    // Om Fault finns, logga och returnera error
+    // If Fault exists, log and return error
     if (isset($bodyChildren->Fault)) {
         error_log('BeautyFort SOAP Fault: ' . print_r($bodyChildren->Fault, true));
         return new WP_Error('soap_fault', 'BeautyFort API returnerade ett fel.');
@@ -92,7 +92,7 @@ if (!$response) {
     return new WP_Error('no_response', 'Hittade inget GetStockFileResponse i SOAP-svaret.');
 }
 
-// Nu vet vi att File finns
+// At this point we know File exists
 $encodedFile = (string) $response->File;
 $decodedXml = base64_decode($encodedFile, true);
 
@@ -107,7 +107,7 @@ if (!$stockXml) {
 return $stockXml;
 
 
-    // Räcker att verifiera att vi fick ett giltigt stockfile
+    // It is enough to verify that we received a valid stockfile
     if (!isset($stockXml->item)) {
         return new WP_Error(
             'invalid_stockfile',

--- a/_old/includes/class-markup-calculator.php
+++ b/_old/includes/class-markup-calculator.php
@@ -5,7 +5,7 @@ class NEBF_Markup_Calculator
 {
 
     /**
-     * Beräkna slutpris från cost price + margin + rounding
+     * Calculate final price from cost price + margin + rounding
      *
      * @param float $cost_price
      * @param array $margin ['type'=>'percent|fixed', 'value'=>float]
@@ -22,7 +22,7 @@ class NEBF_Markup_Calculator
     }
 
     /**
-     * Lägg på markup
+     * Apply markup
      */
     private static function apply_markup($cost_price, $margin)
     {
@@ -38,7 +38,7 @@ class NEBF_Markup_Calculator
     }
 
     /**
-     * Avrunda pris enligt inställning
+     * Round price according to setting
      */
     private static function apply_rounding($price, $rounding)
     {

--- a/_old/includes/helpers.php
+++ b/_old/includes/helpers.php
@@ -2,11 +2,11 @@
 if (!defined('ABSPATH')) exit;
 
 /**
- * Hjälpfunktioner för Beauty Fort
+ * Helper functions for BeautyFort
  */
 
 /**
- * Statusikon för produkt
+ * Status icon for product
  */
 function nebf_get_status_icon($status)
 {
@@ -21,7 +21,7 @@ function nebf_get_status_icon($status)
 }
 
 /**
- * Thumbnail för produkt
+ * Thumbnail for product
  */
 function nebf_get_product_thumbnail($product, $size = 'thumbnail')
 {
@@ -37,7 +37,7 @@ function nebf_get_product_thumbnail($product, $size = 'thumbnail')
 }
 
 /**
- * Renderar produktdetaljer
+ * Renders product details
  */
 function nebf_render_product_details($product)
 {
@@ -88,7 +88,7 @@ function nebf_render_product_details($product)
 }
 
 /**
- * Hämtar produkter från WooCommerce
+ * Fetches products from WooCommerce
  */
 function nebf_get_wc_products($args = [])
 {
@@ -119,7 +119,7 @@ function nebf_get_wc_products($args = [])
             'weight'     => $product->get_weight(),
             'categories' => wc_get_product_category_list($product->get_id()),
             'permalink'  => get_edit_post_link($product->get_id()),
-            'raw'        => $product, // för detaljvisning
+            'raw'        => $product, // for detail view
         ];
     }
 
@@ -127,7 +127,7 @@ function nebf_get_wc_products($args = [])
 }
 
 /**
- * Rensar produktnamn från varumärke
+ * Cleans product name from brand
  */
 function nebf_clean_product_name($name, $brand)
 {
@@ -143,7 +143,7 @@ function nebf_clean_product_name($name, $brand)
 }
 
 /**
- * Formaterar ett fält (sträng eller array)
+ * Formats a field (string or array)
  */
 function nebf_format_field($field)
 {
@@ -155,7 +155,7 @@ function nebf_format_field($field)
 }
 
 /**
- * Genererar sorteringslänk för tabellkolumner
+ * Generates sorting link for table columns
  */
 function nebf_sort_link($column, $current_orderby, $current_order, $label)
 {

--- a/_old/includes/product-import.php
+++ b/_old/includes/product-import.php
@@ -6,7 +6,7 @@ function nebf_import_products()
 {
     error_log('NEBF: Starting product import from BeautyFort API');
 
-    // Hämta data från BeautyFort
+    // Fetch data from BeautyFort
     $rows = nebf_api_request_stockfile();
 
     if (is_wp_error($rows)) {
@@ -51,7 +51,7 @@ function nebf_import_products()
             'stock_level' => $stock,
             'price' => isset($row['Price']) ? (float)$row['Price'] : 0,
 
-            // Produktdata
+            // Product data
             'barcode' => $row['Barcode'] ?? '',
             'brand'   => $brand,
             'category' => $row['Category'] ?? '',
@@ -68,18 +68,18 @@ function nebf_import_products()
             'thumbnail_url'    => $row['ThumbnailImageUrl'] ?? '',
             'image_last_updated' => $row['ImageLastUpdated'] ?? '',
 
-            // Historik
+            // History
             'last_purchased_date' => $row['LastPurchasedDate'] ?? '',
             'last_purchased_price' => $row['LastPurchasedPrice'] ?? '',
             'your_rating'       => $row['YourRating'] ?? '',
             'your_stock_code'   => $row['YourStockCode'] ?? '',
 
-            // Alltid rådata
+            // Always raw data
             'raw' => $row,
         ];
     }
 
-    // --- Spara alltid i DB ---
+    // --- Always save in DB ---
     update_option('nebf_beautyfort_products', $products);
 
     error_log('NEBF: Cached products in DB: ' . count($products));

--- a/_old/js/ne-beauty-woo-admin.js
+++ b/_old/js/ne-beauty-woo-admin.js
@@ -17,11 +17,11 @@ jQuery(function ($) {
     }
 
     /* =========================
-       SÖK-indikator
+       SEARCH indicator
     ========================= */
     const $searchInput = $('#nebf-live-search');
 
-    // Skapa indikator om den inte finns
+    // Create indicator if it does not exist
     if (!$('#nebf-search-indicator').length) {
         $('<span id="nebf-search-indicator" style="margin-left:8px; display:none; font-style:italic;">Söker…</span>')
             .insertAfter($searchInput);
@@ -32,7 +32,7 @@ jQuery(function ($) {
        ACCORDION
     ========================= */
     $(document).on('click', 'tr.product-row', function (e) {
-        // Ignorera klick på checkbox eller label
+        // Ignore clicks on checkbox or label
         if ($(e.target).is('input[type="checkbox"], label')) return;
 
         const $row = $(this);
@@ -40,17 +40,17 @@ jQuery(function ($) {
         const $accordion = $('#' + accId);
         if (!$accordion.length) return;
 
-        // Stäng alla andra accordion-rader och ta bort 'is-open' från andra rader
+        // Close all other accordion rows and remove 'is-open' from them
         $('tr.accordion-row').not($accordion).hide();
         $('tr.product-row').not($row).removeClass('is-open');
 
-        // Toggle den klickade raden
+        // Toggle the clicked row
         $accordion.toggle();
         $row.toggleClass('is-open');
     });
 
     /* =========================
-       VÄLJ ALLA / AVMARKERA ALLA
+       SELECT ALL / DESELECT ALL
     ========================= */
     const $selectAllBtn = $('#nebf-select-all');
 
@@ -59,7 +59,7 @@ jQuery(function ($) {
 
         const $checkboxes = $('tr.product-row input[type="checkbox"]');
 
-        // Om minst en inte är markerad → markera alla, annars avmarkera alla
+        // If at least one is unchecked, check all; otherwise uncheck all
         const allChecked = $checkboxes.length === $checkboxes.filter(':checked').length;
 
         if (allChecked) {
@@ -72,7 +72,7 @@ jQuery(function ($) {
     });
 
     /* =========================
-       LIVE-SÖK (3+ tecken)
+       LIVE SEARCH (3+ characters)
     ========================= */
     const handleLiveSearch = nebfDebounce(function () {
         const value = $searchInput.val().toLowerCase();
@@ -91,7 +91,7 @@ jQuery(function ($) {
 
             $row.toggle(match);
 
-            // Stäng detaljer om huvudraden döljs
+            // Close details if the main row is hidden
             if (!match && accId) {
                 $('#' + accId).hide();
             }
@@ -110,19 +110,19 @@ jQuery(function ($) {
     });
 
     /* =========================
-       MARKERA VALD RAD
+       HIGHLIGHT SELECTED ROW
     ========================= */
     $(document).on('change', 'tr.product-row input[type="checkbox"]', function () {
         const $row = $(this).closest('tr.product-row');
         $row.toggleClass('is-selected', this.checked);
 
-        // Uppdatera knapptext dynamiskt
+        // Update button text dynamically
         const $checkboxes = $('tr.product-row input[type="checkbox"]');
         const allChecked = $checkboxes.length === $checkboxes.filter(':checked').length;
         $selectAllBtn.text(allChecked ? 'Avmarkera alla' : 'Välj alla');
     });
 
-    // Om sidan laddas med redan valda checkboxar
+    // If the page loads with pre-selected checkboxes
     $('tr.product-row input[type="checkbox"]:checked').each(function () {
         $(this).closest('tr.product-row').addClass('is-selected');
     });


### PR DESCRIPTION
### Motivation
- Improve maintainability and consistency by converting legacy Swedish comments, docblocks and inline notes to English across the legacy `_old` code so future contributors can more easily read and maintain the code.

### Description
- Translated Swedish comments and docblocks to English in legacy `_old` PHP files, notably `admin-control-page.php`, `products-page.php`, `settings-action.php`, `settings-page.php`, `includes/api-client.php`, `includes/class-markup-calculator.php`, `includes/helpers.php` and `includes/product-import.php`.
- Updated inline comments in `_old/js/ne-beauty-woo-admin.js` and `_old/css/nebf-style.css` to English and standardized a few admin table header labels (e.g. `Brand`, `Collection`, `PRODUCT TABLE`) for clarity.
- No functional code paths were changed; modifications are limited to comments, docblocks and minor admin label text.

### Testing
- Ran PHP syntax checks using `php -l` for the modified PHP files and all reported `No syntax errors detected` for ` _old/admin/admin-control-page.php`, `_old/admin/products-page.php`, `_old/admin/settings-action.php`, `_old/admin/settings-page.php`, `_old/includes/api-client.php`, `_old/includes/class-markup-calculator.php`, `_old/includes/helpers.php`, and `_old/includes/product-import.php`.
- Performed a static review of the edited JS/CSS and confirmed changes are comment-only; no JS runtime linting was executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699860e40ba48329b05b9698f08b4842)