### PR TITLE
Add external web price lookup to product extra info

### DIFF
--- a/admin/views/products.php
+++ b/admin/views/products.php
@@ -225,6 +225,34 @@ $nebf_float = static function ($value, float $default = 0.0) use ($nebf_scalar):
                                     <th><?php _e('BF ID', 'nebf'); ?></th>
                                     <td><?= esc_html($nebf_display($product['bf_id'] ?? null, '')); ?></td>
                                 </tr>
+                                <tr>
+                                    <th><?php _e('Extra info', 'nebf'); ?></th>
+                                    <td>
+                                        <?php
+                                        $web_prices = $product['web_price_lookup']['matches'] ?? [];
+                                        $web_error = trim((string) ($product['web_price_lookup']['error'] ?? ''));
+                                        if (!empty($web_prices) && is_array($web_prices)):
+                                        ?>
+                                            <ul style="margin:0; padding-left:18px;">
+                                                <?php foreach ($web_prices as $match): ?>
+                                                    <li>
+                                                        <strong><?= esc_html((string) ($match['price'] ?? '')); ?></strong>
+                                                        <?php if (!empty($match['source'])): ?>
+                                                            — <?= esc_html((string) $match['source']); ?>
+                                                        <?php endif; ?>
+                                                        <?php if (!empty($match['url'])): ?>
+                                                            (<a href="<?= esc_url((string) $match['url']); ?>" target="_blank" rel="noopener noreferrer"><?php _e('Open', 'nebf'); ?></a>)
+                                                        <?php endif; ?>
+                                                    </li>
+                                                <?php endforeach; ?>
+                                            </ul>
+                                        <?php elseif ($web_error !== ''): ?>
+                                            <?= esc_html($web_error); ?>
+                                        <?php else: ?>
+                                            <?= esc_html__('No external web prices found.', 'nebf-mvc'); ?>
+                                        <?php endif; ?>
+                                    </td>
+                                </tr>
                             </tbody>
                         </table>
                     </td>

--- a/includes/Models/ProductRepository.php
+++ b/includes/Models/ProductRepository.php
@@ -3,11 +3,19 @@
 namespace NEBF\Models;
 
 use NEBF\Services\ProductSyncService;
+use NEBF\Services\WebPriceLookupService;
 
 if (!defined('ABSPATH')) exit;
 
 class ProductRepository
 {
+    private WebPriceLookupService $webPriceLookup;
+
+    public function __construct()
+    {
+        $this->webPriceLookup = new WebPriceLookupService();
+    }
+
     /**
      * Calculate sale price from cost and pricing settings.
      *
@@ -155,6 +163,7 @@ class ProductRepository
 
             $item['synced'] = $synced_by_bf_id || (!empty($sku) && (bool) wc_get_product_id_by_sku($sku));
             $item['sale_price'] = $this->calculate_sale_price($item);
+            $item['web_price_lookup'] = $this->webPriceLookup->lookup_for_product($item);
         }
 
         unset($item);

--- a/includes/Services/WebPriceLookupService.php
+++ b/includes/Services/WebPriceLookupService.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace NEBF\Services;
+
+if (!defined('ABSPATH')) exit;
+
+/**
+ * Looks up publicly visible web prices for BeautyFort products.
+ */
+class WebPriceLookupService
+{
+    private const CACHE_TTL = 12 * HOUR_IN_SECONDS;
+
+    /**
+     * @param array $product
+     * @return array{query:string,matches:array<int,array{price:string,url:string,source:string,title:string}>,fetched_at:string,error:string}
+     */
+    public function lookup_for_product(array $product): array
+    {
+        $cache_key = $this->build_cache_key($product);
+        $cached = get_transient($cache_key);
+        if (is_array($cached)) {
+            return $cached;
+        }
+
+        $query = $this->build_query($product);
+        if ($query === '') {
+            return $this->default_result(__('No searchable product data found.', 'nebf-mvc'));
+        }
+
+        $result = $this->fetch_prices_from_duckduckgo($query);
+        set_transient($cache_key, $result, self::CACHE_TTL);
+
+        return $result;
+    }
+
+    private function fetch_prices_from_duckduckgo(string $query): array
+    {
+        $url = add_query_arg([
+            'q' => $query . ' pris',
+            'kl' => 'se-sv',
+        ], 'https://duckduckgo.com/html/');
+
+        $response = wp_remote_get($url, [
+            'timeout' => 8,
+            'redirection' => 3,
+            'headers' => [
+                'User-Agent' => 'Mozilla/5.0 (compatible; NEBF price lookup)',
+            ],
+        ]);
+
+        if (is_wp_error($response)) {
+            return $this->default_result($response->get_error_message(), $query);
+        }
+
+        $html = (string) wp_remote_retrieve_body($response);
+        if ($html === '') {
+            return $this->default_result(__('No response body from search provider.', 'nebf-mvc'), $query);
+        }
+
+        $matches = [];
+        if (preg_match_all('/<a[^>]*class="result__a"[^>]*href="([^"]+)"[^>]*>(.*?)<\/a>/si', $html, $anchors, PREG_SET_ORDER)) {
+            foreach ($anchors as $anchor) {
+                $rawUrl = html_entity_decode(wp_strip_all_tags((string) ($anchor[1] ?? '')));
+                $title = trim(wp_strip_all_tags((string) ($anchor[2] ?? '')));
+
+                $price = $this->extract_price_candidate($title);
+                if ($price === '') {
+                    continue;
+                }
+
+                $matches[] = [
+                    'price' => $price,
+                    'url' => esc_url_raw($rawUrl),
+                    'source' => $this->extract_domain($rawUrl),
+                    'title' => $title,
+                ];
+
+                if (count($matches) >= 3) {
+                    break;
+                }
+            }
+        }
+
+        return [
+            'query' => $query,
+            'matches' => $matches,
+            'fetched_at' => gmdate('c'),
+            'error' => '',
+        ];
+    }
+
+    private function extract_price_candidate(string $text): string
+    {
+        $text = html_entity_decode($text);
+
+        if (preg_match('/\b\d{1,5}(?:[\.,]\d{2})?\s?(?:kr|sek)\b/i', $text, $match)) {
+            return trim($match[0]);
+        }
+
+        if (preg_match('/\b(?:kr|sek)\s?\d{1,5}(?:[\.,]\d{2})?\b/i', $text, $match)) {
+            return trim($match[0]);
+        }
+
+        return '';
+    }
+
+    private function extract_domain(string $url): string
+    {
+        $host = (string) wp_parse_url($url, PHP_URL_HOST);
+        if ($host === '') {
+            return '';
+        }
+
+        return preg_replace('/^www\./', '', strtolower($host));
+    }
+
+    private function build_query(array $product): string
+    {
+        $parts = [
+            sanitize_text_field((string) ($product['brand'] ?? '')),
+            sanitize_text_field((string) ($product['fullname'] ?? '')),
+            sanitize_text_field((string) ($product['barcode'] ?? '')),
+            sanitize_text_field((string) ($product['sku'] ?? '')),
+        ];
+
+        $parts = array_filter(array_unique(array_map('trim', $parts)));
+        return trim(implode(' ', $parts));
+    }
+
+    private function build_cache_key(array $product): string
+    {
+        $identifier = (string) ($product['bf_id'] ?? $product['sku'] ?? wp_json_encode($product));
+        return 'nebf_web_price_' . md5($identifier);
+    }
+
+    private function default_result(string $error, string $query = ''): array
+    {
+        return [
+            'query' => $query,
+            'matches' => [],
+            'fetched_at' => gmdate('c'),
+            'error' => $error,
+        ];
+    }
+}
+


### PR DESCRIPTION
### Motivation
- Provide a quick way for admins to see publicly visible web prices for BeautyFort products in the product "Extra info" accordion to aid pricing/market comparison.

### Description
- Add `NEBF\Services\WebPriceLookupService` (`includes/Services/WebPriceLookupService.php`) that performs a web search (DuckDuckGo HTML endpoint), extracts SEK/kr price candidates from result titles, and caches results per product for 12 hours via `set_transient`.
- Wire the lookup into `ProductRepository` by instantiating `WebPriceLookupService` and adding a `web_price_lookup` field to each paginated product item returned by `get_paginated` (`includes/Models/ProductRepository.php`).
- Update the admin product accordion view to show an "Extra info" row with found web price matches (price, source domain and link) or friendly fallback/error messages (`admin/views/products.php`).

### Testing
- Ran PHP lint checks: `php -l includes/Services/WebPriceLookupService.php`, `php -l includes/Models/ProductRepository.php`, and `php -l admin/views/products.php`, all reported no syntax errors.
- Attempted a Playwright page capture to validate the admin UI, but no local web server responded (`ERR_EMPTY_RESPONSE`), so no screenshot could be produced in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699867c3d4b48329a0965d70f59d364f)