### PR TITLE
Fix brand/product name splitting and edge punctuation cleanup

### DIFF
--- a/includes/Controllers/DashboardController.php
+++ b/includes/Controllers/DashboardController.php
@@ -62,14 +62,12 @@ class DashboardController extends AbstractAdminController
             $loaded_count = count($api_products);
             update_option('nebf_last_sync', time());
 
-            // Respect "Separate Brand" setting.
-            $separate = (bool) get_option('nebf_separate_brand', 0);
             foreach ($api_products as &$product) {
                 $brand = (string) ($product['brand'] ?? '');
                 $name = (string) ($product['fullname'] ?? '');
 
-                if ($separate && $brand !== '' && stripos($name, $brand) === 0) {
-                    $name = trim(substr($name, strlen($brand)));
+                if (function_exists('nebf_clean_product_name')) {
+                    $name = (string) nebf_clean_product_name($name, $brand);
                 }
 
                 $product['brand'] = $brand;

--- a/includes/Support/helpers.php
+++ b/includes/Support/helpers.php
@@ -1,0 +1,44 @@
+<?php
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+if (!function_exists('nebf_clean_product_name')) {
+    /**
+     * Remove brand prefix from product name when separate-brand setting is enabled,
+     * and trim leading/trailing punctuation around the final name.
+     */
+    function nebf_clean_product_name(string $name, string $brand): string
+    {
+        $name = trim($name);
+        $brand = trim($brand);
+
+        if ($name === '') {
+            return '';
+        }
+
+        $separate_brand = (bool) get_option('nebf_separate_brand', 0);
+        if (!$separate_brand || $brand === '') {
+            return $name;
+        }
+
+        $clean_name = $name;
+        $brand_pattern = preg_quote($brand, '/');
+
+        // Allow punctuation/symbols around a leading brand match.
+        $prefixed_pattern = '/^\s*[\p{P}\p{S}]*\s*' . $brand_pattern . '(?:\s*[\p{P}\p{S}]*)?/iu';
+        $result = preg_replace($prefixed_pattern, '', $clean_name, 1);
+        if (is_string($result)) {
+            $clean_name = $result;
+        }
+
+        // Remove punctuation/symbols only from beginning and end after split.
+        $trimmed_edges = preg_replace('/^[\p{P}\p{S}\s]+|[\p{P}\p{S}\s]+$/u', '', $clean_name);
+        if (is_string($trimmed_edges)) {
+            $clean_name = $trimmed_edges;
+        }
+
+        return trim($clean_name);
+    }
+}

--- a/ne-bf-woo-mvc.php
+++ b/ne-bf-woo-mvc.php
@@ -36,6 +36,7 @@ add_action('plugins_loaded', 'nebf_mvc_load_textdomain');
  * Load autoloader
  */
 require_once NEBF_MVC_PATH . 'includes/Core/Autoloader.php';
+require_once NEBF_MVC_PATH . 'includes/Support/helpers.php';
 
 /**
  * Bootstrap plugin


### PR DESCRIPTION
### Motivation
- The import flow could fail to separate brand and product name when the brand was surrounded by punctuation or symbols, leaving malformed product names.
- The project lacked a shared helper loaded at bootstrap to provide consistent cleanup logic across import mapping and dashboard normalization.

### Description
- Add `includes/Support/helpers.php` with `nebf_clean_product_name()` that only splits when `nebf_separate_brand` is enabled, tolerates surrounding punctuation/symbols around a leading brand, and trims punctuation at the start/end of the resulting name.
- Load the new helper during plugin bootstrap by requiring `includes/Support/helpers.php` from `ne-bf-woo-mvc.php` so the function is always available.
- Update `includes/Controllers/DashboardController.php` to call `nebf_clean_product_name()` for import normalization instead of the previous `stripos(...)=0` logic for more robust behavior.

### Testing
- Ran `php -l includes/Support/helpers.php` and it reported no syntax errors.
- Ran `php -l includes/Controllers/DashboardController.php` and it reported no syntax errors.
- Ran `php -l ne-bf-woo-mvc.php` and it reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cc4f8ff4c8329bbd854ac20b9eb33)