### PR TITLE
Add BeautyFort CreateOrder test order UI, service method and integration tests

### DIFF
--- a/admin/views/test-order.php
+++ b/admin/views/test-order.php
@@ -1,0 +1,73 @@
+<?php
+
+if (!defined('ABSPATH')) exit;
+
+/** @var array<string,mixed>|\WP_Error|null $result */
+$result = $result ?? null;
+?>
+
+<div class="wrap nebf-settings">
+    <p><?php esc_html_e('Create a test order directly against BeautyFort CreateOrder API.', 'nebf-mvc'); ?></p>
+
+    <form method="post">
+        <?php wp_nonce_field('nebf_create_test_order'); ?>
+
+        <table class="form-table">
+            <tbody>
+                <tr>
+                    <th scope="row"><label for="nebf_order_type"><?php esc_html_e('Order Type', 'nebf-mvc'); ?></label></th>
+                    <td>
+                        <select name="nebf_order_type" id="nebf_order_type">
+                            <option value="Wholesale"><?php esc_html_e('Wholesale', 'nebf-mvc'); ?></option>
+                            <option value="Direct Dispatch"><?php esc_html_e('Direct Dispatch', 'nebf-mvc'); ?></option>
+                        </select>
+                    </td>
+                </tr>
+                <tr>
+                    <th scope="row"><label for="nebf_order_reference"><?php esc_html_e('YourOrderReference', 'nebf-mvc'); ?></label></th>
+                    <td>
+                        <input type="text" name="nebf_order_reference" id="nebf_order_reference" class="regular-text"
+                               value="<?php echo esc_attr('TEST-' . gmdate('Ymd-His')); ?>">
+                        <p class="description"><?php esc_html_e('Must be unique across BeautyFort test and live for your account.', 'nebf-mvc'); ?></p>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+
+        <p class="submit">
+            <button type="submit" class="button button-primary"><?php esc_html_e('Create Test Order', 'nebf-mvc'); ?></button>
+        </p>
+    </form>
+
+    <?php if (is_array($result)) : ?>
+        <h2><?php esc_html_e('CreateOrder Response', 'nebf-mvc'); ?></h2>
+        <table class="widefat striped" style="max-width:900px;">
+            <tbody>
+                <tr>
+                    <th><?php esc_html_e('Success', 'nebf-mvc'); ?></th>
+                    <td><?php echo !empty($result['success']) ? 'true' : 'false'; ?></td>
+                </tr>
+                <tr>
+                    <th><?php esc_html_e('TestMode', 'nebf-mvc'); ?></th>
+                    <td><?php echo !empty($result['test_mode']) ? 'true' : 'false'; ?></td>
+                </tr>
+                <tr>
+                    <th><?php esc_html_e('OrderReference', 'nebf-mvc'); ?></th>
+                    <td><?php echo esc_html((string) ($result['order_reference'] ?? '')); ?></td>
+                </tr>
+                <tr>
+                    <th><?php esc_html_e('YourOrderReference', 'nebf-mvc'); ?></th>
+                    <td><?php echo esc_html((string) ($result['your_order_reference'] ?? '')); ?></td>
+                </tr>
+                <tr>
+                    <th><?php esc_html_e('Errors', 'nebf-mvc'); ?></th>
+                    <td><pre style="margin:0;"><?php echo esc_html(wp_json_encode($result['errors'] ?? [], JSON_PRETTY_PRINT)); ?></pre></td>
+                </tr>
+                <tr>
+                    <th><?php esc_html_e('Warnings', 'nebf-mvc'); ?></th>
+                    <td><pre style="margin:0;"><?php echo esc_html(wp_json_encode($result['warnings'] ?? [], JSON_PRETTY_PRINT)); ?></pre></td>
+                </tr>
+            </tbody>
+        </table>
+    <?php endif; ?>
+</div>

--- a/includes/Controllers/AdminMenuController.php
+++ b/includes/Controllers/AdminMenuController.php
@@ -25,11 +25,29 @@ class AdminMenuController {
                 'nebf-mvc',
                 [$this, 'render']
             );
+
+            add_submenu_page(
+                'woocommerce',
+                __('BeautyFort Test Order', 'nebf-mvc'),
+                __('BeautyFort Test Order', 'nebf-mvc'),
+                'manage_options',
+                'nebf-mvc-test-order',
+                [$this, 'render_test_order']
+            );
         }
     }
 
     public function render(): void
     {
         (new AdminPageRouter())->handle();
+    }
+
+    public function render_test_order(): void
+    {
+        echo '<div class="wrap">';
+        echo '<h1>' . esc_html__('BeautyFort Test Order', 'nebf-mvc') . '</h1>';
+        echo '</div>';
+
+        (new TestOrderController())->handle();
     }
 }

--- a/includes/Controllers/TestOrderController.php
+++ b/includes/Controllers/TestOrderController.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace NEBF\Controllers;
+
+use NEBF\Services\BeautyFortApiService;
+
+if (!defined('ABSPATH')) exit;
+
+/**
+ * Controller for sending BeautyFort test orders from WP admin.
+ */
+class TestOrderController extends AbstractAdminController
+{
+    public function handle(): void
+    {
+        $result = null;
+
+        if ($_SERVER['REQUEST_METHOD'] === 'POST' && check_admin_referer('nebf_create_test_order')) {
+            $type = isset($_POST['nebf_order_type']) ? sanitize_text_field((string) $_POST['nebf_order_type']) : '';
+            $yourOrderReference = isset($_POST['nebf_order_reference']) ? sanitize_text_field((string) $_POST['nebf_order_reference']) : '';
+
+            $service = new BeautyFortApiService();
+            $result = $service->create_order($type, $yourOrderReference);
+
+            if (is_wp_error($result)) {
+                add_action('admin_notices', function () use ($result) {
+                    echo '<div class="notice notice-error is-dismissible"><p>'
+                        . esc_html(sprintf(__('CreateOrder failed: %s', 'nebf-mvc'), $result->get_error_message()))
+                        . '</p></div>';
+                });
+            } elseif (!empty($result['success'])) {
+                add_action('admin_notices', function () use ($result) {
+                    echo '<div class="notice notice-success is-dismissible"><p>'
+                        . esc_html(sprintf(__('Test order created. OrderReference: %d', 'nebf-mvc'), (int) ($result['order_reference'] ?? 0)))
+                        . '</p></div>';
+                });
+            } else {
+                add_action('admin_notices', function () {
+                    echo '<div class="notice notice-warning is-dismissible"><p>'
+                        . esc_html__('CreateOrder returned validation errors. Check details below.', 'nebf-mvc')
+                        . '</p></div>';
+                });
+            }
+        }
+
+        $this->render('test-order', [
+            'result' => $result,
+        ]);
+    }
+}

--- a/includes/Services/BeautyFortApiService.php
+++ b/includes/Services/BeautyFortApiService.php
@@ -10,6 +10,67 @@ if (!defined('ABSPATH')) exit;
 class BeautyFortApiService
 {
     /**
+     * Create an order in BeautyFort.
+     *
+     * @param string $type Supported values: Wholesale, Direct Dispatch.
+     * @param string $yourOrderReference Optional client side order reference.
+     *
+     * @return array<string, mixed>|\WP_Error
+     */
+    public function create_order(string $type, string $yourOrderReference = '')
+    {
+        $username = get_option('nebf_username', get_option('nebf_api_username', ''));
+        $secret   = get_option('nebf_api_key', get_option('nebf_api_secret', ''));
+        $testmode = get_option('nebf_api_testmode', '0') === '1' ? 'true' : 'false';
+
+        if (!$username || !$secret) {
+            return new \WP_Error('nebf_missing_credentials', __('Missing API credentials. Please check Settings.', 'nebf-mvc'));
+        }
+
+        $validTypes = ['Wholesale', 'Direct Dispatch'];
+        if (!in_array($type, $validTypes, true)) {
+            return new \WP_Error('nebf_invalid_order_type', __('Invalid order type for CreateOrder request.', 'nebf-mvc'));
+        }
+
+        $nonce   = uniqid();
+        $created = date('c');
+        $password = base64_encode(sha1($nonce . $created . $secret));
+
+        $xml = '<?xml version="1.0" encoding="utf-8"?>'
+            . '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:bf="http://www.beautyfort.com/api/">'
+            . '<soap:Header><bf:AuthHeader>'
+            . '<bf:Username>' . esc_xml($username) . '</bf:Username>'
+            . '<bf:Nonce>' . esc_xml($nonce) . '</bf:Nonce>'
+            . '<bf:Created>' . esc_xml($created) . '</bf:Created>'
+            . '<bf:Password>' . esc_xml($password) . '</bf:Password>'
+            . '</bf:AuthHeader></soap:Header>'
+            . '<soap:Body><bf:CreateOrderRequest>'
+            . '<bf:TestMode>' . $testmode . '</bf:TestMode>'
+            . '<bf:Type>' . esc_xml($type) . '</bf:Type>';
+
+        if ($yourOrderReference !== '') {
+            $xml .= '<bf:YourOrderReference>' . esc_xml($yourOrderReference) . '</bf:YourOrderReference>';
+        }
+
+        $xml .= '</bf:CreateOrderRequest></soap:Body></soap:Envelope>';
+
+        $response = wp_remote_post('https://www.beautyfort.com/api/soap', [
+            'headers' => [
+                'Content-Type' => 'text/xml; charset=UTF-8',
+                'Accept'       => 'text/xml',
+            ],
+            'body'    => $xml,
+            'timeout' => 60,
+        ]);
+
+        if (is_wp_error($response)) {
+            return $response;
+        }
+
+        return $this->parse_create_order_response((string) wp_remote_retrieve_body($response));
+    }
+
+    /**
      * Request stockfile from BeautyFort and return decoded stock XML.
      *
      * @return \SimpleXMLElement|\WP_Error
@@ -371,5 +432,66 @@ $soap = $xml_debug->children($ns['SOAP-ENV']);
         ];
 
         update_option('nebf_last_api_raw_response', $snapshot, false);
+    }
+
+    /**
+     * Parse SOAP CreateOrder response into a normalized model.
+     *
+     * @return array<string, mixed>|\WP_Error
+     */
+    private function parse_create_order_response(string $body)
+    {
+        libxml_use_internal_errors(true);
+        $soapXml = simplexml_load_string($body);
+
+        if (!$soapXml) {
+            return new \WP_Error('nebf_invalid_soap_xml', __('Could not parse SOAP XML response.', 'nebf-mvc'));
+        }
+
+        $namespaces = $soapXml->getNamespaces(true);
+        $soapNs = $namespaces['soap'] ?? ($namespaces['SOAP-ENV'] ?? null);
+        $bfNs = $namespaces['bf'] ?? ($namespaces['ns1'] ?? null);
+
+        if (!$soapNs || !$bfNs) {
+            return new \WP_Error('nebf_missing_namespaces', __('Could not locate SOAP namespaces in response.', 'nebf-mvc'));
+        }
+
+        $soap = $soapXml->children($soapNs);
+        $soapBody = $soap->Body;
+        $bf = $soapBody->children($bfNs);
+        $createOrderResponse = $bf->CreateOrderResponse ?? null;
+
+        if (!$createOrderResponse) {
+            return new \WP_Error('nebf_missing_createorder_response', __('Could not find CreateOrderResponse in SOAP response.', 'nebf-mvc'));
+        }
+
+        $errors = [];
+        if (isset($createOrderResponse->Errors->Error)) {
+            foreach ($createOrderResponse->Errors->Error as $error) {
+                $errors[] = [
+                    'code' => (int) ($error->Code ?? 0),
+                    'description' => (string) ($error->Description ?? ''),
+                ];
+            }
+        }
+
+        $warnings = [];
+        if (isset($createOrderResponse->Warnings->Warning)) {
+            foreach ($createOrderResponse->Warnings->Warning as $warning) {
+                $warnings[] = [
+                    'code' => (int) ($warning->Code ?? 0),
+                    'description' => (string) ($warning->Description ?? ''),
+                ];
+            }
+        }
+
+        return [
+            'test_mode' => ((string) ($createOrderResponse->TestMode ?? 'false')) === 'true',
+            'order_reference' => (int) ($createOrderResponse->OrderReference ?? 0),
+            'your_order_reference' => isset($createOrderResponse->YourOrderReference) ? (string) $createOrderResponse->YourOrderReference : null,
+            'errors' => $errors,
+            'warnings' => $warnings,
+            'success' => empty($errors) && (int) ($createOrderResponse->OrderReference ?? 0) > 0,
+        ];
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/bootstrap.php" colors="true">
+  <testsuites>
+    <testsuite name="Integration">
+      <directory>tests/Integration</directory>
+    </testsuite>
+  </testsuites>
+</phpunit>

--- a/tests/Integration/CreateOrderApiIntegrationTest.php
+++ b/tests/Integration/CreateOrderApiIntegrationTest.php
@@ -1,0 +1,131 @@
+<?php
+
+use NEBF\Services\BeautyFortApiService;
+use PHPUnit\Framework\TestCase;
+
+class CreateOrderApiIntegrationTest extends TestCase
+{
+    private BeautyFortApiService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $GLOBALS['nebf_test_options'] = [
+            'nebf_username' => 'integration-user',
+            'nebf_api_key' => 'integration-secret',
+            'nebf_api_testmode' => '1',
+        ];
+        $GLOBALS['nebf_test_last_remote_request'] = null;
+        $GLOBALS['nebf_test_remote_handler'] = null;
+
+        $this->service = new BeautyFortApiService();
+    }
+
+    protected function tearDown(): void
+    {
+        $GLOBALS['nebf_test_options'] = [];
+        $GLOBALS['nebf_test_last_remote_request'] = null;
+        $GLOBALS['nebf_test_remote_handler'] = null;
+
+        parent::tearDown();
+    }
+
+    public function test_create_order_success_returns_expected_response_model(): void
+    {
+        $GLOBALS['nebf_test_remote_handler'] = static function (): array {
+            return [
+                'response' => ['code' => 200],
+                'headers' => ['content-type' => 'text/xml'],
+                'body' => '<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:bf="http://www.beautyfort.com/api/"><soap:Body>
+    <bf:CreateOrderResponse>
+        <bf:TestMode>true</bf:TestMode>
+        <bf:OrderReference>321654</bf:OrderReference>
+        <bf:YourOrderReference>WC-ORDER-1001</bf:YourOrderReference>
+    </bf:CreateOrderResponse>
+</soap:Body></soap:Envelope>',
+            ];
+        };
+
+        $result = $this->service->create_order('Wholesale', 'WC-ORDER-1001');
+
+        $this->assertFalse(is_wp_error($result));
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('test_mode', $result);
+        $this->assertArrayHasKey('order_reference', $result);
+        $this->assertArrayHasKey('your_order_reference', $result);
+        $this->assertArrayHasKey('errors', $result);
+        $this->assertArrayHasKey('warnings', $result);
+        $this->assertArrayHasKey('success', $result);
+
+        $this->assertTrue($result['test_mode']);
+        $this->assertSame(321654, $result['order_reference']);
+        $this->assertSame('WC-ORDER-1001', $result['your_order_reference']);
+        $this->assertSame([], $result['errors']);
+        $this->assertSame([], $result['warnings']);
+        $this->assertTrue($result['success']);
+    }
+
+    public function test_create_order_request_contains_mandatory_fields(): void
+    {
+        $GLOBALS['nebf_test_remote_handler'] = static function (): array {
+            return [
+                'response' => ['code' => 200],
+                'headers' => [],
+                'body' => '<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:bf="http://www.beautyfort.com/api/"><soap:Body>
+    <bf:CreateOrderResponse>
+        <bf:TestMode>true</bf:TestMode>
+        <bf:OrderReference>111</bf:OrderReference>
+    </bf:CreateOrderResponse>
+</soap:Body></soap:Envelope>',
+            ];
+        };
+
+        $this->service->create_order('Wholesale', 'WC-ORDER-1002');
+
+        $request = $GLOBALS['nebf_test_last_remote_request'];
+        $this->assertNotNull($request);
+        $this->assertSame('https://www.beautyfort.com/api/soap', $request['url']);
+
+        $body = $request['args']['body'];
+        $this->assertStringContainsString('<bf:Username>integration-user</bf:Username>', $body);
+        $this->assertMatchesRegularExpression('/<bf:Nonce>[^<]+<\/bf:Nonce>/', $body);
+        $this->assertMatchesRegularExpression('/<bf:Created>[^<]+<\/bf:Created>/', $body);
+        $this->assertMatchesRegularExpression('/<bf:Password>[^<]+<\/bf:Password>/', $body);
+        $this->assertStringContainsString('<bf:TestMode>true</bf:TestMode>', $body);
+        $this->assertStringContainsString('<bf:Type>Wholesale</bf:Type>', $body);
+    }
+
+    public function test_create_order_success_flag_false_when_api_returns_error(): void
+    {
+        $GLOBALS['nebf_test_remote_handler'] = static function (): array {
+            return [
+                'response' => ['code' => 200],
+                'headers' => ['content-type' => 'text/xml'],
+                'body' => '<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:bf="http://www.beautyfort.com/api/"><soap:Body>
+    <bf:CreateOrderResponse>
+        <bf:TestMode>true</bf:TestMode>
+        <bf:Errors>
+            <bf:Error>
+                <bf:Code>4001</bf:Code>
+                <bf:Description>Invalid order type.</bf:Description>
+            </bf:Error>
+        </bf:Errors>
+        <bf:OrderReference>0</bf:OrderReference>
+    </bf:CreateOrderResponse>
+</soap:Body></soap:Envelope>',
+            ];
+        };
+
+        $result = $this->service->create_order('Wholesale', 'WC-ORDER-1003');
+
+        $this->assertFalse(is_wp_error($result));
+        $this->assertFalse($result['success']);
+        $this->assertCount(1, $result['errors']);
+        $this->assertSame(4001, $result['errors'][0]['code']);
+        $this->assertSame('Invalid order type.', $result['errors'][0]['description']);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,93 @@
+<?php
+
+define('ABSPATH', __DIR__);
+
+if (!class_exists('WP_Error')) {
+    class WP_Error
+    {
+        private string $code;
+        private string $message;
+
+        public function __construct(string $code = '', string $message = '')
+        {
+            $this->code = $code;
+            $this->message = $message;
+        }
+
+        public function get_error_code(): string
+        {
+            return $this->code;
+        }
+
+        public function get_error_message(): string
+        {
+            return $this->message;
+        }
+    }
+}
+
+$GLOBALS['nebf_test_options'] = [];
+$GLOBALS['nebf_test_last_remote_request'] = null;
+$GLOBALS['nebf_test_remote_handler'] = null;
+
+function get_option(string $name, $default = false)
+{
+    return $GLOBALS['nebf_test_options'][$name] ?? $default;
+}
+
+function update_option(string $name, $value, $autoload = false): bool
+{
+    $GLOBALS['nebf_test_options'][$name] = $value;
+    return true;
+}
+
+function __(string $text, string $domain = ''): string
+{
+    return $text;
+}
+
+function esc_xml(string $value): string
+{
+    return htmlspecialchars($value, ENT_XML1 | ENT_QUOTES, 'UTF-8');
+}
+
+function wp_json_encode($value)
+{
+    return json_encode($value);
+}
+
+function is_wp_error($value): bool
+{
+    return $value instanceof WP_Error;
+}
+
+function wp_remote_post(string $url, array $args)
+{
+    $GLOBALS['nebf_test_last_remote_request'] = [
+        'url' => $url,
+        'args' => $args,
+    ];
+
+    if (is_callable($GLOBALS['nebf_test_remote_handler'])) {
+        return call_user_func($GLOBALS['nebf_test_remote_handler'], $url, $args);
+    }
+
+    return new WP_Error('nebf_test_missing_http_stub', 'No HTTP stub configured for test.');
+}
+
+function wp_remote_retrieve_body($response): string
+{
+    return is_array($response) ? (string) ($response['body'] ?? '') : '';
+}
+
+function wp_remote_retrieve_response_code($response): int
+{
+    return is_array($response) ? (int) ($response['response']['code'] ?? 0) : 0;
+}
+
+function wp_remote_retrieve_headers($response): array
+{
+    return is_array($response) ? (array) ($response['headers'] ?? []) : [];
+}
+
+require_once dirname(__DIR__) . '/includes/Services/BeautyFortApiService.php';


### PR DESCRIPTION
### Motivation

- Provide an admin UI and controller to create test orders against the BeautyFort CreateOrder SOAP API for debugging and QA. 
- Add a programmatic `create_order` flow and response parsing to validate CreateOrder integration and surface errors/warnings.

### Description

- Added an admin view `admin/views/test-order.php` and a submenu entry in `AdminMenuController` with `render_test_order` to expose a Test Order page in WooCommerce admin. 
- Introduced `TestOrderController` to handle the Test Order form, validate nonce, call `BeautyFortApiService::create_order`, and display admin notices. 
- Extended `BeautyFortApiService` with `create_order` to build and send a signed SOAP CreateOrder request and added `parse_create_order_response` to normalize the SOAP response into an array model with `errors`, `warnings`, `order_reference`, `test_mode`, and `success`. 
- Added integration test harness and tests: `phpunit.xml.dist`, `tests/bootstrap.php` (WP function stubs), and `tests/Integration/CreateOrderApiIntegrationTest.php` which exercise request construction, success parsing, and error handling. 

### Testing

- Ran the integration test suite with `phpunit` targeting the Integration tests, which executed the `CreateOrderApiIntegrationTest` cases. 
- All integration tests completed successfully and validated both request construction and response parsing. 
- Test harness stubs in `tests/bootstrap.php` simulate WordPress option and HTTP functions for deterministic offline testing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cfe5ff7608329922f242e220b0e28)